### PR TITLE
docs: fix simple typo, timeer -> timer

### DIFF
--- a/第十六章/OManager/ServManagerMain.py
+++ b/第十六章/OManager/ServManagerMain.py
@@ -451,7 +451,7 @@ class ServManageFrame(wx.Frame):
         self.Bind(wx.EVT_TIMER,self.OnNotify,self.timer)
         self.timer.Start(1000)
 
-        #Update check timeer
+        #Update check timer
         self.timer_p = wx.Timer(self,id=52)
         self.Bind(wx.EVT_TIMER,self.OnUpdatecheck,self.timer_p)       
         


### PR DESCRIPTION
There is a small typo in 第十六章/OManager/ServManagerMain.py.

Should read `timer` rather than `timeer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md